### PR TITLE
Extend the send method to return server-side values and wait until the connection was started

### DIFF
--- a/src/signalr-hub.spec.ts
+++ b/src/signalr-hub.spec.ts
@@ -82,11 +82,34 @@ describe('SignalRHub', () => {
 
         const hub = new SignalRHub('bob');
         hub.start();
-        await hub.send<any>('method', { data: 'one' });
+        await hub.send('method', { data: 'one' });
 
         expect(connectionStartStub).toHaveBeenCalled();
         expect(proxy.invoke).toHaveBeenCalledWith('method', { data: 'one' });
     });
+
+    it('should allow to invoke a server-side method without any parameters', async () => {
+        spyOn(proxy, 'invoke').and.returnValue(Promise.resolve());;
+
+        const hub = new SignalRHub('bob');
+        hub.start();
+        await hub.send('method');
+
+        expect(connectionStartStub).toHaveBeenCalled();
+        expect(proxy.invoke).toHaveBeenCalledWith('method');
+    });
+
+    it('should allow to invoke a server-side method with more than one parameter', async () => {
+        spyOn(proxy, 'invoke').and.returnValue(Promise.resolve());;
+
+        const hub = new SignalRHub('bob');
+        hub.start();
+        await hub.send('method', 1, 'Hello World', true);
+
+        expect(connectionStartStub).toHaveBeenCalled();
+        expect(proxy.invoke).toHaveBeenCalledWith('method', 1, 'Hello World', true);
+    });
+
 
     it('should fail to send data to server if not started', async () => {
         spyOn(proxy, 'invoke');
@@ -94,7 +117,7 @@ describe('SignalRHub', () => {
         let errorMessage = '';
         const hub = new SignalRHub('bob');
         try {
-            var result = await hub.send<any>('method', { data: 'one' });
+            var result = await hub.send('method', { data: 'one' });
         } catch(error) {
             errorMessage = error; // We expect the promise to be rejected with a string as result. 
                                   // so we cannot use the default error assertion here, as that only
@@ -112,7 +135,7 @@ describe('SignalRHub', () => {
 
         const hub = new SignalRHub('bob');
         hub.start();
-        var result = await hub.send<any>('method', { data: 'one' });
+        var result = await hub.send('method', { data: 'one' });
         
         expect(connectionStartStub).toHaveBeenCalled();
         expect(result).toBe(42);

--- a/src/signalr-hub.spec.ts
+++ b/src/signalr-hub.spec.ts
@@ -86,6 +86,17 @@ describe('SignalRHub', () => {
         expect(proxy.invoke).toHaveBeenCalledWith('method', { data: 'one' });
     });
 
+    it('should return data from proxy', async () => {
+        spyOn(proxy, 'invoke').and.returnValue(Promise.resolve(42));
+
+        const hub = new SignalRHub('bob');
+        hub.start();
+        var result = await hub.send<any>('method', { data: 'one' });
+        
+        expect(result).toBe(42);
+        expect(proxy.invoke).toHaveBeenCalledWith('method', { data: 'one' });
+    });
+
     it('should notify of state change', (done) => {
         let stateChange;
         spyOn(connection, 'stateChanged').and.callFake((callback) => stateChange = callback);

--- a/src/signalr-hub.ts
+++ b/src/signalr-hub.ts
@@ -56,8 +56,8 @@ export class SignalRHub {
         return subject.asObservable();
     }
 
-    send<T>(method: string, data: T) {
-        this.proxy.invoke(method, data);
+    async send<T>(method: string, data: T): Promise<any> {
+        return this.proxy.invoke(method, data);
     }
 
     hasSubscriptions(): boolean {

--- a/src/signalr-hub.ts
+++ b/src/signalr-hub.ts
@@ -57,11 +57,11 @@ export class SignalRHub {
         return subject.asObservable();
     }
 
-    async send<T>(method: string, data: T): Promise<any> {
+    async send(method: string, ...args: any[]): Promise<any> {
         if (!this._primePromise)
             return Promise.reject('The connection has not been started yet. Please start the connection by invoking the start method befor attempting to send a message to the server.');
         await this._primePromise;
-        return this.proxy.invoke(method, data);
+        return this.proxy.invoke(method, ...args);
     }
 
     hasSubscriptions(): boolean {


### PR DESCRIPTION
This PR extends the `send`-method so it actually returns a promise that, once resolved provides the return value of the server-side hub method.
Also this PR introduces a prime promise that gets resolved once the connection has been started. Outgoing calls to the server are now dependent upon the resolved primePromise

Fixes #1 
Fixes #2
Fixes #4

